### PR TITLE
feat: 新規登録画面を追加

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -40,3 +40,29 @@
 .read-the-docs {
   color: #888;
 }
+
+.signup-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 400px;
+  margin: 0 auto;
+  text-align: left;
+}
+
+.signup-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.signup-form input {
+  padding: 0.5rem;
+  font-size: 1rem;
+}
+
+.signup-form button {
+  padding: 0.75rem;
+  font-size: 1rem;
+  cursor: pointer;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,34 +1,11 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
 import './App.css'
+import SignUp from './SignUp'
 
 function App() {
-  const [count, setCount] = useState(0)
-
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    <div className="app">
+      <SignUp />
+    </div>
   )
 }
 

--- a/src/SignUp.tsx
+++ b/src/SignUp.tsx
@@ -1,0 +1,56 @@
+import { useState } from 'react'
+
+interface FormState {
+  name: string
+  email: string
+  password: string
+  confirm: string
+}
+
+function SignUp() {
+  const [form, setForm] = useState<FormState>({
+    name: '',
+    email: '',
+    password: '',
+    confirm: '',
+  })
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target
+    setForm((prev) => ({ ...prev, [name]: value }))
+  }
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (form.password !== form.confirm) {
+      alert('パスワードが一致しません')
+      return
+    }
+    console.log('Registered user:', form)
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="signup-form">
+      <h2>新規登録</h2>
+      <label>
+        名前
+        <input type="text" name="name" value={form.name} onChange={handleChange} />
+      </label>
+      <label>
+        メールアドレス
+        <input type="email" name="email" value={form.email} onChange={handleChange} />
+      </label>
+      <label>
+        パスワード
+        <input type="password" name="password" value={form.password} onChange={handleChange} />
+      </label>
+      <label>
+        パスワード（確認）
+        <input type="password" name="confirm" value={form.confirm} onChange={handleChange} />
+      </label>
+      <button type="submit">登録</button>
+    </form>
+  )
+}
+
+export default SignUp


### PR DESCRIPTION
## 概要
- SignUpコンポーネントを追加し、Appから表示するように変更
- 新規登録フォーム用のスタイルを追加

## テスト
- `npm test` (スクリプト未定義)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5ce5b425483268da7f1b387552e23