### PR TITLE
漢字入力からフリガナを自動生成する機能を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   },
   "dependencies": {
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "kuroshiro": "^1.2.0",
+    "kuroshiro-analyzer-kuromoji": "^1.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/src/SignUp.tsx
+++ b/src/SignUp.tsx
@@ -1,4 +1,7 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
+import Kuroshiro from 'kuroshiro'
+import KuromojiAnalyzer from 'kuroshiro-analyzer-kuromoji'
+import { useMemo } from 'react'
 
 interface FormState {
   name: string
@@ -22,10 +25,21 @@ function SignUp() {
       String.fromCharCode(ch.charCodeAt(0) + 0x60)
     )
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const kuroshiro = useMemo(() => new Kuroshiro(), [])
+  useEffect(() => {
+    kuroshiro.init(new KuromojiAnalyzer()).catch(console.error)
+  }, [kuroshiro])
+
+  const handleChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target
     if (name === 'name') {
-      setForm((prev) => ({ ...prev, name: value, nameKana: toKatakana(value) }))
+      let kana = toKatakana(value)
+      try {
+        kana = await kuroshiro.convert(value, { to: 'katakana' })
+      } catch {
+        /* ignore conversion errors */
+      }
+      setForm((prev) => ({ ...prev, name: value, nameKana: kana }))
     } else if (name === 'nameKana') {
       setForm((prev) => ({ ...prev, nameKana: toKatakana(value) }))
     } else {


### PR DESCRIPTION
## 概要
- `kuroshiro` と `kuroshiro-analyzer-kuromoji` を追加し、漢字からフリガナへの変換を可能にしました。
- `SignUp` コンポーネントで名前入力時に自動的にカタカナへ変換するよう更新しました。

## テスト
- `npm test` : Missing script "test".
- `npm run lint`
- `npm run build` : モジュールが見つからず失敗しました（kuroshiro インストール不可）。

------
https://chatgpt.com/codex/tasks/task_e_68b5d23021688326b9b0b661f7d628f7