### PR TITLE
wanakana を用いたフリガナ自動入力機能の追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,13 +7,13 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "kuroshiro": "^1.2.0",
-    "kuroshiro-analyzer-kuromoji": "^1.1.0"
+    "wanakana": "^5.2.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",
@@ -26,6 +26,11 @@
     "globals": "^16.3.0",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.39.1",
-    "vite": "^7.1.2"
+    "vite": "^7.1.2",
+    "vitest": "^1.6.0",
+    "@testing-library/react": "^16.0.1",
+    "@testing-library/user-event": "^14.5.2",
+    "@testing-library/jest-dom": "^6.2.0",
+    "jsdom": "^24.0.0"
   }
 }

--- a/src/SignUp.test.tsx
+++ b/src/SignUp.test.tsx
@@ -1,0 +1,13 @@
+/// <reference types="vitest" />
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import '@testing-library/jest-dom/vitest'
+import SignUp from './SignUp'
+
+test('名前入力でフリガナが自動入力される', async () => {
+  render(<SignUp />)
+  const nameInput = screen.getByLabelText('名前')
+  const kanaInput = screen.getByLabelText('フリガナ')
+  await userEvent.type(nameInput, 'やまだ')
+  expect(kanaInput).toHaveValue('ヤマダ')
+})

--- a/src/SignUp.tsx
+++ b/src/SignUp.tsx
@@ -1,7 +1,5 @@
-import { useEffect, useState } from 'react'
-import Kuroshiro from 'kuroshiro'
-import KuromojiAnalyzer from 'kuroshiro-analyzer-kuromoji'
-import { useMemo } from 'react'
+import { useState } from 'react'
+import { toKatakana } from 'wanakana'
 
 interface FormState {
   name: string
@@ -20,26 +18,10 @@ function SignUp() {
     confirm: '',
   })
 
-  const toKatakana = (input: string) =>
-    input.replace(/[\u3041-\u3096]/g, (ch) =>
-      String.fromCharCode(ch.charCodeAt(0) + 0x60)
-    )
-
-  const kuroshiro = useMemo(() => new Kuroshiro(), [])
-  useEffect(() => {
-    kuroshiro.init(new KuromojiAnalyzer()).catch(console.error)
-  }, [kuroshiro])
-
-  const handleChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target
     if (name === 'name') {
-      let kana = toKatakana(value)
-      try {
-        kana = await kuroshiro.convert(value, { to: 'katakana' })
-      } catch {
-        /* ignore conversion errors */
-      }
-      setForm((prev) => ({ ...prev, name: value, nameKana: kana }))
+      setForm((prev) => ({ ...prev, name: value, nameKana: toKatakana(value) }))
     } else if (name === 'nameKana') {
       setForm((prev) => ({ ...prev, nameKana: toKatakana(value) }))
     } else {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,10 @@
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  test: {
+    environment: 'jsdom',
+  },
 })


### PR DESCRIPTION
## 概要
- 名前入力からフリガナへの自動変換を wanakana で実装
- フリガナ自動変換のテストを追加
- vitest と Testing Library の導入

## テスト
- `npm test` : ❌ `vitest: not found`

------
https://chatgpt.com/codex/tasks/task_e_68b5d555b04c8326b5be87a00d3f0d18