### PR TITLE
漢字入力時のフリガナ処理を改善

### DIFF
--- a/src/SignUp.test.tsx
+++ b/src/SignUp.test.tsx
@@ -11,3 +11,13 @@ test('名前入力でフリガナが自動入力される', async () => {
   await userEvent.type(nameInput, 'やまだ')
   expect(kanaInput).toHaveValue('ヤマダ')
 })
+
+test('漢字入力ではフリガナは自動入力されない', async () => {
+  render(<SignUp />)
+  const nameInput = screen.getByLabelText('名前')
+  const kanaInput = screen.getByLabelText('フリガナ')
+  await userEvent.type(nameInput, '山田')
+  expect(kanaInput).toHaveValue('')
+  await userEvent.type(kanaInput, 'やまだ')
+  expect(kanaInput).toHaveValue('ヤマダ')
+})

--- a/src/SignUp.tsx
+++ b/src/SignUp.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { toKatakana } from 'wanakana'
+import { toKatakana, isKanji } from 'wanakana'
 
 interface FormState {
   name: string
@@ -18,10 +18,13 @@ function SignUp() {
     confirm: '',
   })
 
+  const containsKanji = (text: string) => [...text].some((ch) => isKanji(ch))
+
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target
     if (name === 'name') {
-      setForm((prev) => ({ ...prev, name: value, nameKana: toKatakana(value) }))
+      const nameKana = containsKanji(value) ? '' : toKatakana(value)
+      setForm((prev) => ({ ...prev, name: value, nameKana }))
     } else if (name === 'nameKana') {
       setForm((prev) => ({ ...prev, nameKana: toKatakana(value) }))
     } else {


### PR DESCRIPTION
## 概要
- 名前入力に漢字が含まれる場合は自動でフリガナを空にする処理を追加
- 漢字入力時にフリガナが自動入力されないことを確認するテストを追加

## テスト
- `npm test` : `vitest: not found`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5d75e7d24832699fd1c635030c97a