### PR TITLE
react-use-kanaフックの導入

### DIFF
--- a/src/SignUp.tsx
+++ b/src/SignUp.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react'
-import AutoKana from 'vanilla-autokana'
+import useKana from 'react-use-kana'
 import { toKatakana } from 'wanakana'
 
 interface FormState {
@@ -20,14 +20,11 @@ function SignUp() {
   })
 
   const nameRef = useRef<HTMLInputElement>(null)
-  const nameKanaRef = useRef<HTMLInputElement>(null)
+  const kana = useKana(nameRef, { katakana: true })
 
   useEffect(() => {
-    if (nameRef.current && nameKanaRef.current) {
-      const autoKana = AutoKana.bind(nameRef.current, nameKanaRef.current, { katakana: true })
-      return () => autoKana.unbind()
-    }
-  }, [])
+    setForm((prev) => ({ ...prev, nameKana: kana }))
+  }, [kana])
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target
@@ -69,7 +66,6 @@ function SignUp() {
           name="nameKana"
           value={form.nameKana}
           onChange={handleChange}
-          ref={nameKanaRef}
         />
       </label>
       <label>

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -8,7 +8,7 @@
     "skipLibCheck": true,
     "baseUrl": ".",
     "paths": {
-      "vanilla-autokana": ["src/vanilla-autokana.ts"]
+      "react-use-kana": ["src/react-use-kana.ts"]
     },
 
     /* Bundler mode */


### PR DESCRIPTION
## 概要
- react-use-kanaフックを実装し、サインアップフォームで名前からフリガナを自動生成するように変更
- tsconfigのパスエイリアスを更新

## テスト
- `npm test`: 依存パッケージがインストールできず `vitest: not found` で失敗


------
https://chatgpt.com/codex/tasks/task_e_68b5dae9ee80832687273ee67e1fd988