### PR TITLE
フリガナ自動変換機能の追加

### DIFF
--- a/src/SignUp.test.tsx
+++ b/src/SignUp.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import '@testing-library/jest-dom'
+import SignUp from './SignUp'
+
+describe('SignUp', () => {
+  it('kanji name input autofills katakana furigana', async () => {
+    const user = userEvent.setup()
+    render(<SignUp />)
+    const nameInput = screen.getByLabelText('名前')
+    const kanaInput = screen.getByLabelText('フリガナ')
+    await user.type(nameInput, '山田太郎')
+    expect(kanaInput).toHaveValue('ヤマダタロウ')
+  })
+
+  it('hiragana name input autofills katakana furigana', async () => {
+    const user = userEvent.setup()
+    render(<SignUp />)
+    const nameInput = screen.getByLabelText('名前')
+    const kanaInput = screen.getByLabelText('フリガナ')
+    await user.type(nameInput, 'たなかじろう')
+    expect(kanaInput).toHaveValue('タナカジロウ')
+  })
+})

--- a/src/SignUp.tsx
+++ b/src/SignUp.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef } from 'react'
+import { toKatakana } from 'wanakana'
 
 interface FormState {
   name: string
@@ -22,7 +23,7 @@ function SignUp() {
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target
     if (name === 'name') {
-      setForm((prev) => ({ ...prev, name: value }))
+      setForm((prev) => ({ ...prev, name: value, nameKana: toKatakana(value) }))
     } else {
       setForm((prev) => ({ ...prev, [name]: value }))
     }


### PR DESCRIPTION
## 概要
- 名前入力に応じてフリガナをカタカナで自動入力するテストを追加
- 名前入力時にリアルタイムでフリガナを自動変換する機能を実装

## テスト
- `npm test`（vitest が見つからず失敗）

------
https://chatgpt.com/codex/tasks/task_e_68b5df4613bc8326857edf7df47360d2