### PR TITLE
vanilla-autokanaによるかな自動変換の導入

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,13 +1,19 @@
 <!doctype html>
-<html lang="en">
+<html lang="ja">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css"
+    />
     <title>Vite + React + TS</title>
   </head>
   <body>
     <div id="root"></div>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/vanilla-autokana@1.0.0/dist/vanilla-autokana.min.js"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "dependencies": {
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "wanakana": "^5.2.0"
+    "materialize-css": "^1.0.0",
+    "vanilla-autokana": "^1.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/src/App.css
+++ b/src/App.css
@@ -41,28 +41,3 @@
   color: #888;
 }
 
-.signup-form {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  max-width: 400px;
-  margin: 0 auto;
-  text-align: left;
-}
-
-.signup-form label {
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-}
-
-.signup-form input {
-  padding: 0.5rem;
-  font-size: 1rem;
-}
-
-.signup-form button {
-  padding: 0.75rem;
-  font-size: 1rem;
-  cursor: pointer;
-}

--- a/src/SignUp.tsx
+++ b/src/SignUp.tsx
@@ -1,5 +1,4 @@
-import { useState, useRef } from 'react'
-import { toKatakana } from 'wanakana'
+import { useState, useEffect } from 'react'
 
 interface FormState {
   name: string
@@ -18,15 +17,26 @@ function SignUp() {
     confirm: '',
   })
 
-  const nameRef = useRef<HTMLInputElement>(null)
+  useEffect(() => {
+    const autoKana = (window as any).autoKana
+    if (autoKana) {
+      autoKana('#name', '#nameKana', { katakana: true })
+    }
+    const kanaInput = document.getElementById('nameKana') as HTMLInputElement | null
+    const syncKana = () => {
+      if (kanaInput) {
+        setForm((prev) => ({ ...prev, nameKana: kanaInput.value }))
+      }
+    }
+    kanaInput?.addEventListener('input', syncKana)
+    return () => {
+      kanaInput?.removeEventListener('input', syncKana)
+    }
+  }, [])
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target
-    if (name === 'name') {
-      setForm((prev) => ({ ...prev, name: value, nameKana: toKatakana(value) }))
-    } else {
-      setForm((prev) => ({ ...prev, [name]: value }))
-    }
+    setForm((prev) => ({ ...prev, [name]: value }))
   }
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -39,40 +49,55 @@ function SignUp() {
   }
 
   return (
-    <form onSubmit={handleSubmit} className="signup-form">
-      <h2>新規登録</h2>
-      <label>
-        名前
+    <form onSubmit={handleSubmit} className="container">
+      <h2 className="center-align">新規登録</h2>
+      <div className="input-field">
         <input
+          id="name"
           type="text"
           name="name"
           value={form.name}
           onChange={handleChange}
-          ref={nameRef}
         />
-      </label>
-      <label>
-        フリガナ
+        <label htmlFor="name">名前</label>
+      </div>
+      <div className="input-field">
+        <input id="nameKana" type="text" name="nameKana" onChange={handleChange} />
+        <label htmlFor="nameKana">フリガナ</label>
+      </div>
+      <div className="input-field">
         <input
-          type="text"
-          name="nameKana"
-          value={form.nameKana}
+          id="email"
+          type="email"
+          name="email"
+          value={form.email}
           onChange={handleChange}
         />
-      </label>
-      <label>
-        メールアドレス
-        <input type="email" name="email" value={form.email} onChange={handleChange} />
-      </label>
-      <label>
-        パスワード
-        <input type="password" name="password" value={form.password} onChange={handleChange} />
-      </label>
-      <label>
-        パスワード（確認）
-        <input type="password" name="confirm" value={form.confirm} onChange={handleChange} />
-      </label>
-      <button type="submit">登録</button>
+        <label htmlFor="email">メールアドレス</label>
+      </div>
+      <div className="input-field">
+        <input
+          id="password"
+          type="password"
+          name="password"
+          value={form.password}
+          onChange={handleChange}
+        />
+        <label htmlFor="password">パスワード</label>
+      </div>
+      <div className="input-field">
+        <input
+          id="confirm"
+          type="password"
+          name="confirm"
+          value={form.confirm}
+          onChange={handleChange}
+        />
+        <label htmlFor="confirm">パスワード（確認）</label>
+      </div>
+      <button className="btn waves-effect waves-light" type="submit">
+        登録
+      </button>
     </form>
   )
 }


### PR DESCRIPTION
## 概要
- vanilla-autokanaをCDN経由で導入し、名前入力からフリガナを自動生成
- Materialize CSSを利用してフォームをマテリアルデザイン化

## テスト
- `npm test` : vitestが見つからず実行できず
- `npm run lint` : 依存関係不足により失敗

------
https://chatgpt.com/codex/tasks/task_e_68b67b4e5e9083268e43898f79c466c1