### PR TITLE
IMEイベントでフリガナ自動生成

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,6 @@
   <body>
     <div id="root"></div>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/vanilla-autokana@1.0.0/dist/vanilla-autokana.min.js"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.1.1",
-        "react-dom": "^19.1.1",
-        "wanakana": "^5.2.0"
+        "react-dom": "^19.1.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
@@ -6022,15 +6021,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/wanakana": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/wanakana/-/wanakana-5.3.1.tgz",
-      "integrity": "sha512-OSDqupzTlzl2LGyqTdhcXcl6ezMiFhcUwLBP8YKaBIbMYW1wAwDvupw2T9G9oVaKT9RmaSpyTXjxddFPUcFFIw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
   "dependencies": {
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "materialize-css": "^1.0.0",
-    "vanilla-autokana": "^1.0.0"
+    "materialize-css": "^1.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",


### PR DESCRIPTION
## 概要
- かな変換ライブラリを削除
- IMEのcompositionイベントからフリガナを自動反映

## テスト
- `npm test` (vitestが見つからず失敗)
- `npm run lint` (@eslint/jsが見つからず失敗)


------
https://chatgpt.com/codex/tasks/task_e_68b68053d678832680402535caf2ec4d