### PR TITLE
IME入力のイベントシーケンスに関するテスト追加

### DIFF
--- a/src/SignUp.test.tsx
+++ b/src/SignUp.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import SignUp from './SignUp'
+
+describe('SignUp IME input flow', () => {
+  it('updates kana field through typical composition events', () => {
+    render(<SignUp />)
+    const nameInput = screen.getByLabelText('名前') as HTMLInputElement
+    const kanaInput = screen.getByLabelText('フリガナ') as HTMLInputElement
+
+    // Step 0: initial state
+    expect(kanaInput).toHaveValue('')
+
+    // Step 1: compositionstart
+    fireEvent.compositionStart(nameInput, { data: '' })
+    expect(kanaInput).toHaveValue('')
+
+    // Step 2: incremental compositionupdate
+    fireEvent.compositionUpdate(nameInput, { data: 'お' })
+    expect(kanaInput).toHaveValue('オ')
+    fireEvent.compositionUpdate(nameInput, { data: 'おお' })
+    expect(kanaInput).toHaveValue('オオ')
+    fireEvent.compositionUpdate(nameInput, { data: 'おおか' })
+    expect(kanaInput).toHaveValue('オオカ')
+
+    // beforeinput with difference "わ"
+    fireEvent.beforeInput(nameInput, {
+      data: 'わ',
+      inputType: 'insertCompositionText',
+    } as any)
+    expect(kanaInput).toHaveValue('ワ')
+
+    fireEvent.compositionUpdate(nameInput, { data: 'おおかわ' })
+    expect(kanaInput).toHaveValue('オオカワ')
+
+    // Step 4: compositionend
+    fireEvent.compositionEnd(nameInput, { data: 'おおかわ' })
+    expect(kanaInput).toHaveValue('オオカワ')
+  })
+})
+


### PR DESCRIPTION
## 概要
- IME入力の典型的なイベントフローを検証するテストを追加

## テスト
- `npm test` (vitest が未インストールのため失敗)
- `npm run lint` (@eslint/js が見つからず失敗)

------
https://chatgpt.com/codex/tasks/task_e_68b68211b9608326b830afdc637afd29