### PR TITLE
IME確定時にカタカナが漢字で上書きされる問題を修正

### DIFF
--- a/src/SignUp.test.tsx
+++ b/src/SignUp.test.tsx
@@ -1,5 +1,6 @@
+import { describe, it, expect } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
-import '@testing-library/jest-dom'
+import '@testing-library/jest-dom/vitest'
 import SignUp from './SignUp'
 
 describe('SignUp IME input flow', () => {
@@ -24,17 +25,22 @@ describe('SignUp IME input flow', () => {
     expect(kanaInput).toHaveValue('オオカ')
 
     // beforeinput with difference "わ"
-    fireEvent.beforeInput(nameInput, {
-      data: 'わ',
-      inputType: 'insertCompositionText',
-    } as any)
+    fireEvent(
+      nameInput,
+      new InputEvent('beforeinput', {
+        data: 'わ',
+        inputType: 'insertCompositionText',
+        bubbles: true,
+        cancelable: true,
+      }),
+    )
     expect(kanaInput).toHaveValue('ワ')
 
     fireEvent.compositionUpdate(nameInput, { data: 'おおかわ' })
     expect(kanaInput).toHaveValue('オオカワ')
 
-    // Step 4: compositionend
-    fireEvent.compositionEnd(nameInput, { data: 'おおかわ' })
+    // Step 4: compositionend produces kanji
+    fireEvent.compositionEnd(nameInput, { data: '大川' })
     expect(kanaInput).toHaveValue('オオカワ')
   })
 })

--- a/src/SignUp.tsx
+++ b/src/SignUp.tsx
@@ -43,6 +43,7 @@ function SignUp() {
     }
 
     const handleCompositionEnd = (e: CompositionEvent) => {
+      if (!/[ぁ-ん]/.test(e.data)) return
       const kana = toKatakana(e.data)
       setForm((prev) =>
         prev.nameKana === kana ? prev : { ...prev, nameKana: kana },


### PR DESCRIPTION
## 概要
- compositionend で漢字が入力された際にフリガナが漢字で上書きされる不具合を修正
- IME入力フローのテストを調整

## テスト
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b68bd474d88326851333a38c762b8e