### PR TITLE
漢字をカタカナへ変換するボタンを追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,8 @@
   <body>
     <div id="root"></div>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/kuroshiro@1.1.1/dist/kuroshiro.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/kuroshiro-analyzer-kuromoji@1.1.1/dist/kuroshiro-analyzer-kuromoji.min.js"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
   "dependencies": {
     "materialize-css": "^1.0.0",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "kuroshiro": "^1.1.1",
+    "kuroshiro-analyzer-kuromoji": "^1.1.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",


### PR DESCRIPTION
## 概要
- 「カナ変換」ボタンで名前の漢字をカタカナへ変換
- Kuroshiro を CDN 経由で読み込み、依存関係を追加
- 変換機能のテストを追加

## テスト
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b68e51b44c83268fc970c8ff320f8f