### PR TITLE
パスワードに条件を追加

### DIFF
--- a/src/SignUp.test.tsx
+++ b/src/SignUp.test.tsx
@@ -95,5 +95,23 @@ describe('SignUp IME input flow', () => {
     )
     ;(global as any).fetch = originalFetch
   })
+
+  it('alerts when password does not meet conditions', () => {
+    render(<SignUp />)
+    const passwordInput = screen.getByLabelText('パスワード') as HTMLInputElement
+    const confirmInput = screen.getByLabelText('パスワード（確認）') as HTMLInputElement
+    fireEvent.change(passwordInput, {
+      target: { value: 'short1', name: 'password' },
+    })
+    fireEvent.change(confirmInput, {
+      target: { value: 'short1', name: 'confirm' },
+    })
+    const alertMock = vi.spyOn(window, 'alert').mockImplementation(() => {})
+    const submitButton = screen.getByRole('button', { name: '登録' })
+    fireEvent.click(submitButton)
+    expect(alertMock).toHaveBeenCalledWith(
+      'パスワードは8文字以上で英字と数字を含めてください',
+    )
+  })
 })
 

--- a/src/SignUp.tsx
+++ b/src/SignUp.tsx
@@ -143,6 +143,11 @@ function SignUp() {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
+    const passwordRegex = /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,}$/
+    if (!passwordRegex.test(form.password)) {
+      alert('パスワードは8文字以上で英字と数字を含めてください')
+      return
+    }
     if (form.password !== form.confirm) {
       alert('パスワードが一致しません')
       return
@@ -224,6 +229,8 @@ function SignUp() {
           name="password"
           value={form.password}
           onChange={handleChange}
+          pattern="(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}"
+          title="8文字以上で英字と数字を含めてください"
         />
         <label htmlFor="password">パスワード</label>
       </div>
@@ -234,6 +241,8 @@ function SignUp() {
           name="confirm"
           value={form.confirm}
           onChange={handleChange}
+          pattern="(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]{8,}"
+          title="8文字以上で英字と数字を含めてください"
         />
         <label htmlFor="confirm">パスワード（確認）</label>
       </div>


### PR DESCRIPTION
## 概要
- パスワードに英数字を含む8文字以上のバリデーションを追加
- パスワード入力欄にパターンと説明を付与
- 条件に合わない場合にアラートが出るテストを追加

## テスト
- `npm test` : vitest が見つからず失敗
- `npm run lint` : @eslint/js が見つからず失敗

------
https://chatgpt.com/codex/tasks/task_e_68b6c4df63d483268786faecb728a8db